### PR TITLE
Bug in docker-compose.yml  `expose` was used instead of `ports`.

### DIFF
--- a/source/install/files/docker-compose.yml
+++ b/source/install/files/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ./data:/data
       # Mount your media directories below /data
       - ${HOME}/Pictures:/data/Pictures
-    expose:
+    ports:
       - "3000:3000"
     user: "${CURRENT_USER}"
     entrypoint: ['node', '/app/gallery.js', 'run', 'server']


### PR DESCRIPTION
Fixed a bug in docker-compose, `expose` was used instead of `ports`.

This led to : 
```
docker-compose up -d 
ERROR: Compose file './docker-compose.yml' is invalid because :
services.gallery.expose is invalid: must be in 'PORT[/PROTOCOL]' format.
```